### PR TITLE
New Changes

### DIFF
--- a/translations/harbour-seaprint-de.ts
+++ b/translations/harbour-seaprint-de.ts
@@ -461,11 +461,11 @@
     </message>
     <message>
         <source>Clear default settings</source>
-        <translation>Standardeinstellungen wiederherstellen</translation>
+        <translation>Standardeinstellungen löschen</translation>
     </message>
     <message>
         <source>Save default settings</source>
-        <translation>Als Standarteinstellung speichern</translation>
+        <translation>Einstellungen speichern</translation>
     </message>
     <message>
         <source>Default settings for %1 on this printer</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Ignore SSL errors</source>
-        <translation>SSL Fehler ignorieren</translation>
+        <translation>SSL-Fehler ignorieren</translation>
     </message>
     <message>
         <source>In order to work with self-signed certificates of printers and CUPS instances, SSL errors needs to be ignored.</source>


### PR DESCRIPTION
- Line 468: The translation is indeed correct. But i think it is confusing because the button "Save default setting" saves my changes and not the default. 
- Line 557: Looks better with the -

- Line 471: The user don`t need this hint because the user know where he is, I think. Otherwise it should rather be called "Settings for %1 on this printer". In german "Einstellung für %1 auf diesem Drucker".