### PR TITLE
New update to prevent misunderstandings

### DIFF
--- a/translations/harbour-seaprint-de.ts
+++ b/translations/harbour-seaprint-de.ts
@@ -460,16 +460,16 @@
         <translation>Sortierte Kopien</translation>
     </message>
     <message>
-        <source>Clear default settings</source>
-        <translation>Standardeinstellungen löschen</translation>
+        <source>Reset default settings</source>
+        <translation>Standardeinstellungen zurücksetzen</translation>
     </message>
     <message>
-        <source>Save default settings</source>
-        <translation>Als Standarteinstellung speichern</translation>
+        <source>Save my settings as default</source>
+        <translation>Meine Einstellung als Standard speichern</translation>
     </message>
     <message>
         <source>Default settings for %1 on this printer</source>
-        <translation>Standarteinstellung für %1 auf diesem Drucker</translation>
+        <translation>Standardeinstellung für %1 auf diesem Drucker</translation>
     </message>
     <message>
         <source>(loaded)</source>


### PR DESCRIPTION
Line 463/464, line 467/467:
I'm starting here again because I think it's important for the user to avoid misunderstandings. I know that my changes will be long for one line. But what's wrong with buttons with multiple lines?

Line 472: small typo. Can you also put this hint in two lines. The current state doesn't look so good and especially disturbs the reading flow. For example:

Default settings for documents
         on this printer

In my opinion it is not a problem if the slide menu becomes bigger.

