### PR TITLE
"en" language specified for base language file

### DIFF
--- a/translations/harbour-seaprint.ts
+++ b/translations/harbour-seaprint.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="en">>
 <context>
     <name>AboutPage</name>
     <message>


### PR DESCRIPTION
This in the "don't know why else it would fail" department.
Hopefully Weblate likes it that way, because that is how the other languages are structured.